### PR TITLE
implement dotted notation from RTTL

### DIFF
--- a/c/bloopsaphone.c
+++ b/c/bloopsaphone.c
@@ -253,7 +253,8 @@ bloops_synth(int length, float* buffer)
                 A->period = 100.0 / (freq * freq + 0.001);
               }
 
-              A->nextnote[0] += (int)(tempo2frames(B->tempo) * (4.0f / note->duration));
+              float invduration = 4.0f / note->duration + (note->dot ? 2.0f / note->duration : 0);
+              A->nextnote[0] += (int)(tempo2frames(B->tempo) * invduration);
             }
             A->nextnote[1]++;
           }

--- a/c/bloopsaphone.h
+++ b/c/bloopsaphone.h
@@ -75,7 +75,7 @@ typedef struct bloopsafx_tag {
 } bloopsafx;
 
 typedef struct {
-  char tone, octave, duration;
+  char tone, octave, duration, dot;
   bloopsafx *FX;
 } bloopsanote;
 

--- a/c/notation.c
+++ b/c/notation.c
@@ -1,3 +1,4 @@
+
 #line 1 "c/notation.rl"
 //
 // notation.rl
@@ -37,10 +38,11 @@
   len = 4; \
   fxval = 0; \
   fxmod = 0; \
+  dot = 0; \
   S->nlen++
 
 
-#line 44 "c/notation.c"
+#line 46 "c/notation.c"
 static const char _bloopnotes_actions[] = {
 	0, 1, 1, 1, 3, 1, 4, 1, 
 	6, 1, 8, 1, 9, 1, 10, 1, 
@@ -50,14 +52,15 @@ static const char _bloopnotes_actions[] = {
 	23, 1, 24, 1, 25, 1, 26, 1, 
 	27, 1, 28, 1, 29, 1, 30, 1, 
 	31, 1, 32, 1, 33, 1, 34, 1, 
-	35, 1, 36, 1, 41, 2, 0, 37, 
-	2, 0, 39, 2, 0, 40, 2, 28, 
-	39, 2, 29, 40, 2, 35, 0, 2, 
-	35, 5, 2, 35, 30, 2, 35, 32, 
-	3, 1, 2, 38, 3, 3, 2, 38, 
-	3, 30, 2, 38, 3, 32, 2, 38, 
-	3, 35, 4, 5, 3, 35, 5, 7, 
-	4, 35, 4, 5, 7
+	35, 1, 36, 1, 37, 1, 42, 2, 
+	0, 38, 2, 0, 40, 2, 0, 41, 
+	2, 28, 40, 2, 29, 41, 2, 36, 
+	0, 2, 36, 5, 2, 36, 30, 2, 
+	36, 32, 2, 36, 33, 3, 1, 2, 
+	39, 3, 3, 2, 39, 3, 30, 2, 
+	39, 3, 32, 2, 39, 3, 33, 2, 
+	39, 3, 36, 4, 5, 3, 36, 5, 
+	7, 4, 36, 4, 5, 7
 };
 
 static const short _bloopnotes_key_offsets[] = {
@@ -76,7 +79,7 @@ static const short _bloopnotes_key_offsets[] = {
 	263, 264, 272, 273, 274, 282, 283, 284, 
 	285, 286, 294, 295, 296, 297, 298, 306, 
 	317, 319, 322, 323, 323, 325, 328, 329, 
-	329, 336, 341, 345, 350, 353, 354
+	329, 336, 341, 345, 351, 354, 355, 356
 };
 
 static const char _bloopnotes_trans_keys[] = {
@@ -123,8 +126,9 @@ static const char _bloopnotes_trans_keys[] = {
 	48, 57, 58, 49, 57, 58, 48, 57, 
 	58, 58, 48, 57, 65, 71, 97, 103, 
 	58, 65, 71, 97, 103, 65, 71, 97, 
-	103, 35, 91, 98, 49, 56, 91, 49, 
-	56, 91, 91, 0
+	103, 35, 46, 91, 98, 49, 56, 91, 
+	49, 56, 91, 91, 35, 91, 98, 49, 
+	56, 0
 };
 
 static const char _bloopnotes_single_lengths[] = {
@@ -143,7 +147,7 @@ static const char _bloopnotes_single_lengths[] = {
 	1, 4, 1, 1, 4, 1, 1, 1, 
 	1, 4, 1, 1, 1, 1, 4, 3, 
 	0, 1, 1, 0, 0, 1, 1, 0, 
-	1, 1, 0, 3, 1, 1, 1
+	1, 1, 0, 4, 1, 1, 1, 3
 };
 
 static const char _bloopnotes_range_lengths[] = {
@@ -162,7 +166,7 @@ static const char _bloopnotes_range_lengths[] = {
 	0, 2, 0, 0, 2, 0, 0, 0, 
 	0, 2, 0, 0, 0, 0, 2, 4, 
 	1, 1, 0, 0, 1, 1, 0, 0, 
-	3, 2, 2, 1, 1, 0, 0
+	3, 2, 2, 1, 1, 0, 0, 1
 };
 
 static const short _bloopnotes_index_offsets[] = {
@@ -181,7 +185,7 @@ static const short _bloopnotes_index_offsets[] = {
 	310, 312, 319, 321, 323, 330, 332, 334, 
 	336, 338, 345, 347, 349, 351, 353, 360, 
 	368, 370, 373, 375, 376, 378, 381, 383, 
-	384, 389, 393, 396, 401, 404, 406
+	384, 389, 393, 396, 402, 405, 407, 409
 };
 
 static const char _bloopnotes_trans_targs[] = {
@@ -234,8 +238,9 @@ static const char _bloopnotes_trans_targs[] = {
 	113, 111, 115, 114, 111, 115, 111, 111, 
 	117, 111, 119, 118, 111, 119, 111, 111, 
 	122, 121, 123, 123, 111, 122, 123, 123, 
-	111, 123, 123, 111, 124, 1, 124, 125, 
-	111, 1, 125, 111, 1, 111, 1, 111, 
+	111, 123, 123, 111, 124, 127, 1, 124, 
+	125, 111, 1, 125, 111, 1, 111, 1, 
+	111, 124, 1, 124, 125, 111, 111, 111, 
 	111, 111, 111, 111, 111, 111, 111, 111, 
 	111, 111, 111, 111, 111, 111, 111, 111, 
 	111, 111, 111, 111, 111, 111, 111, 111, 
@@ -251,99 +256,81 @@ static const char _bloopnotes_trans_targs[] = {
 	111, 111, 111, 111, 111, 111, 111, 111, 
 	111, 111, 111, 111, 111, 111, 111, 111, 
 	111, 111, 111, 111, 111, 111, 111, 111, 
-	111, 111, 111, 111, 111, 0
+	111, 111, 111, 111, 0
 };
 
-static const char _bloopnotes_trans_actions[] = {
+static const unsigned char _bloopnotes_trans_actions[] = {
 	0, 0, 0, 0, 0, 0, 0, 0, 
-	67, 0, 0, 0, 67, 0, 67, 39, 
-	39, 39, 39, 39, 39, 67, 0, 0, 
-	0, 0, 0, 67, 55, 55, 55, 67, 
-	0, 0, 0, 0, 67, 0, 67, 5, 
-	120, 0, 67, 7, 67, 116, 0, 67, 
-	5, 112, 0, 67, 7, 67, 87, 0, 
-	67, 0, 0, 67, 55, 55, 55, 0, 
-	67, 0, 0, 0, 67, 0, 67, 0, 
-	67, 0, 67, 0, 67, 41, 41, 41, 
-	41, 41, 41, 67, 0, 67, 0, 67, 
-	0, 67, 0, 67, 13, 13, 13, 13, 
-	13, 13, 67, 0, 67, 0, 67, 0, 
-	67, 0, 67, 17, 17, 17, 17, 17, 
-	17, 67, 0, 0, 67, 0, 67, 35, 
-	35, 35, 35, 35, 35, 67, 0, 67, 
-	0, 67, 0, 67, 0, 67, 37, 37, 
-	37, 37, 37, 37, 67, 0, 0, 67, 
-	0, 67, 29, 29, 29, 29, 29, 29, 
-	67, 0, 67, 0, 67, 0, 67, 0, 
-	67, 31, 31, 31, 31, 31, 31, 67, 
-	0, 0, 0, 67, 0, 67, 0, 67, 
-	0, 67, 43, 43, 43, 43, 43, 43, 
-	67, 0, 67, 0, 67, 0, 67, 0, 
-	67, 45, 45, 45, 45, 45, 45, 67, 
-	0, 67, 0, 67, 0, 67, 11, 11, 
-	11, 11, 11, 11, 67, 0, 67, 0, 
-	0, 67, 0, 67, 0, 67, 0, 67, 
-	47, 47, 47, 47, 47, 47, 67, 0, 
-	67, 0, 67, 0, 67, 0, 67, 0, 
-	67, 0, 67, 33, 33, 33, 33, 33, 
-	33, 67, 0, 0, 0, 67, 0, 67, 
-	0, 67, 0, 67, 0, 67, 19, 19, 
-	19, 19, 19, 19, 67, 0, 67, 0, 
-	67, 0, 67, 0, 67, 0, 67, 15, 
-	15, 15, 15, 15, 15, 67, 0, 67, 
-	0, 67, 0, 67, 21, 21, 21, 21, 
-	21, 21, 67, 0, 0, 0, 0, 67, 
-	0, 67, 0, 67, 0, 67, 0, 67, 
-	27, 27, 27, 27, 27, 27, 67, 0, 
-	67, 0, 67, 23, 23, 23, 23, 23, 
-	23, 67, 0, 67, 0, 67, 0, 67, 
-	0, 67, 9, 9, 9, 9, 9, 9, 
-	67, 0, 67, 0, 67, 0, 67, 0, 
-	67, 25, 25, 25, 25, 25, 25, 67, 
-	65, 0, 0, 65, 0, 63, 63, 0, 
-	49, 78, 0, 0, 72, 0, 72, 72, 
-	51, 81, 0, 0, 75, 0, 75, 75, 
-	0, 0, 84, 84, 69, 0, 84, 84, 
-	69, 84, 84, 69, 93, 57, 93, 93, 
-	108, 53, 90, 104, 1, 96, 3, 100, 
-	67, 67, 67, 67, 67, 67, 67, 67, 
-	67, 67, 67, 67, 67, 67, 67, 67, 
-	67, 67, 67, 67, 67, 67, 67, 67, 
-	67, 67, 67, 67, 67, 67, 67, 67, 
-	67, 67, 67, 67, 67, 67, 67, 67, 
-	67, 67, 67, 67, 67, 67, 67, 67, 
-	67, 67, 67, 67, 67, 67, 67, 67, 
-	67, 67, 67, 67, 67, 67, 67, 67, 
-	67, 67, 67, 67, 67, 67, 67, 67, 
-	67, 67, 67, 67, 67, 67, 67, 67, 
-	67, 67, 67, 67, 67, 67, 67, 67, 
-	67, 67, 67, 67, 67, 67, 67, 67, 
-	67, 67, 67, 67, 67, 67, 67, 67, 
-	67, 67, 67, 67, 67, 67, 78, 72, 
-	72, 72, 81, 75, 75, 75, 69, 69, 
-	69, 108, 104, 96, 100, 0
+	69, 0, 0, 0, 69, 0, 69, 39, 
+	39, 39, 39, 39, 39, 69, 0, 0, 
+	0, 0, 0, 69, 55, 55, 55, 69, 
+	0, 0, 0, 0, 69, 0, 69, 5, 
+	129, 0, 69, 7, 69, 125, 0, 69, 
+	5, 121, 0, 69, 7, 69, 89, 0, 
+	69, 0, 0, 69, 55, 55, 55, 0, 
+	69, 0, 0, 0, 69, 0, 69, 0, 
+	69, 0, 69, 0, 69, 41, 41, 41, 
+	41, 41, 41, 69, 0, 69, 0, 69, 
+	0, 69, 0, 69, 13, 13, 13, 13, 
+	13, 13, 69, 0, 69, 0, 69, 0, 
+	69, 0, 69, 17, 17, 17, 17, 17, 
+	17, 69, 0, 0, 69, 0, 69, 35, 
+	35, 35, 35, 35, 35, 69, 0, 69, 
+	0, 69, 0, 69, 0, 69, 37, 37, 
+	37, 37, 37, 37, 69, 0, 0, 69, 
+	0, 69, 29, 29, 29, 29, 29, 29, 
+	69, 0, 69, 0, 69, 0, 69, 0, 
+	69, 31, 31, 31, 31, 31, 31, 69, 
+	0, 0, 0, 69, 0, 69, 0, 69, 
+	0, 69, 43, 43, 43, 43, 43, 43, 
+	69, 0, 69, 0, 69, 0, 69, 0, 
+	69, 45, 45, 45, 45, 45, 45, 69, 
+	0, 69, 0, 69, 0, 69, 11, 11, 
+	11, 11, 11, 11, 69, 0, 69, 0, 
+	0, 69, 0, 69, 0, 69, 0, 69, 
+	47, 47, 47, 47, 47, 47, 69, 0, 
+	69, 0, 69, 0, 69, 0, 69, 0, 
+	69, 0, 69, 33, 33, 33, 33, 33, 
+	33, 69, 0, 0, 0, 69, 0, 69, 
+	0, 69, 0, 69, 0, 69, 19, 19, 
+	19, 19, 19, 19, 69, 0, 69, 0, 
+	69, 0, 69, 0, 69, 0, 69, 15, 
+	15, 15, 15, 15, 15, 69, 0, 69, 
+	0, 69, 0, 69, 21, 21, 21, 21, 
+	21, 21, 69, 0, 0, 0, 0, 69, 
+	0, 69, 0, 69, 0, 69, 0, 69, 
+	27, 27, 27, 27, 27, 27, 69, 0, 
+	69, 0, 69, 23, 23, 23, 23, 23, 
+	23, 69, 0, 69, 0, 69, 0, 69, 
+	0, 69, 9, 9, 9, 9, 9, 9, 
+	69, 0, 69, 0, 69, 0, 69, 0, 
+	69, 25, 25, 25, 25, 25, 25, 69, 
+	67, 0, 0, 67, 0, 65, 65, 0, 
+	49, 80, 0, 0, 74, 0, 74, 74, 
+	51, 83, 0, 0, 77, 0, 77, 77, 
+	0, 0, 86, 86, 71, 0, 86, 86, 
+	71, 86, 86, 71, 98, 98, 59, 98, 
+	98, 117, 53, 92, 109, 1, 101, 3, 
+	105, 95, 57, 95, 95, 113, 69, 69, 
+	69, 69, 69, 69, 69, 69, 69, 69, 
+	69, 69, 69, 69, 69, 69, 69, 69, 
+	69, 69, 69, 69, 69, 69, 69, 69, 
+	69, 69, 69, 69, 69, 69, 69, 69, 
+	69, 69, 69, 69, 69, 69, 69, 69, 
+	69, 69, 69, 69, 69, 69, 69, 69, 
+	69, 69, 69, 69, 69, 69, 69, 69, 
+	69, 69, 69, 69, 69, 69, 69, 69, 
+	69, 69, 69, 69, 69, 69, 69, 69, 
+	69, 69, 69, 69, 69, 69, 69, 69, 
+	69, 69, 69, 69, 69, 69, 69, 69, 
+	69, 69, 69, 69, 69, 69, 69, 69, 
+	69, 69, 69, 69, 69, 69, 69, 69, 
+	69, 69, 69, 69, 80, 74, 74, 74, 
+	83, 77, 77, 77, 71, 71, 71, 117, 
+	109, 101, 105, 113, 0
 };
 
-static const char _bloopnotes_to_state_actions[] = {
-	0, 0, 0, 0, 0, 0, 0, 0, 
-	0, 0, 0, 0, 0, 0, 0, 0, 
-	0, 0, 0, 0, 0, 0, 0, 0, 
-	0, 0, 0, 0, 0, 0, 0, 0, 
-	0, 0, 0, 0, 0, 0, 0, 0, 
-	0, 0, 0, 0, 0, 0, 0, 0, 
-	0, 0, 0, 0, 0, 0, 0, 0, 
-	0, 0, 0, 0, 0, 0, 0, 0, 
-	0, 0, 0, 0, 0, 0, 0, 0, 
-	0, 0, 0, 0, 0, 0, 0, 0, 
-	0, 0, 0, 0, 0, 0, 0, 0, 
-	0, 0, 0, 0, 0, 0, 0, 0, 
-	0, 0, 0, 0, 0, 0, 0, 0, 
-	0, 0, 0, 0, 0, 0, 0, 59, 
-	0, 0, 0, 0, 0, 0, 0, 0, 
-	0, 0, 0, 0, 0, 0, 0
-};
-
-static const char _bloopnotes_from_state_actions[] = {
+static const unsigned char _bloopnotes_to_state_actions[] = {
 	0, 0, 0, 0, 0, 0, 0, 0, 
 	0, 0, 0, 0, 0, 0, 0, 0, 
 	0, 0, 0, 0, 0, 0, 0, 0, 
@@ -359,26 +346,45 @@ static const char _bloopnotes_from_state_actions[] = {
 	0, 0, 0, 0, 0, 0, 0, 0, 
 	0, 0, 0, 0, 0, 0, 0, 61, 
 	0, 0, 0, 0, 0, 0, 0, 0, 
-	0, 0, 0, 0, 0, 0, 0
+	0, 0, 0, 0, 0, 0, 0, 0
+};
+
+static const unsigned char _bloopnotes_from_state_actions[] = {
+	0, 0, 0, 0, 0, 0, 0, 0, 
+	0, 0, 0, 0, 0, 0, 0, 0, 
+	0, 0, 0, 0, 0, 0, 0, 0, 
+	0, 0, 0, 0, 0, 0, 0, 0, 
+	0, 0, 0, 0, 0, 0, 0, 0, 
+	0, 0, 0, 0, 0, 0, 0, 0, 
+	0, 0, 0, 0, 0, 0, 0, 0, 
+	0, 0, 0, 0, 0, 0, 0, 0, 
+	0, 0, 0, 0, 0, 0, 0, 0, 
+	0, 0, 0, 0, 0, 0, 0, 0, 
+	0, 0, 0, 0, 0, 0, 0, 0, 
+	0, 0, 0, 0, 0, 0, 0, 0, 
+	0, 0, 0, 0, 0, 0, 0, 0, 
+	0, 0, 0, 0, 0, 0, 0, 63, 
+	0, 0, 0, 0, 0, 0, 0, 0, 
+	0, 0, 0, 0, 0, 0, 0, 0
 };
 
 static const short _bloopnotes_eof_trans[] = {
-	0, 518, 518, 518, 518, 518, 518, 518, 
-	518, 518, 518, 518, 518, 518, 518, 518, 
-	518, 518, 518, 518, 518, 518, 518, 518, 
-	518, 518, 518, 518, 518, 518, 518, 518, 
-	518, 518, 518, 518, 518, 518, 518, 518, 
-	518, 518, 518, 518, 518, 518, 518, 518, 
-	518, 518, 518, 518, 518, 518, 518, 518, 
-	518, 518, 518, 518, 518, 518, 518, 518, 
-	518, 518, 518, 518, 518, 518, 518, 518, 
-	518, 518, 518, 518, 518, 518, 518, 518, 
-	518, 518, 518, 518, 518, 518, 518, 518, 
-	518, 518, 518, 518, 518, 518, 518, 518, 
-	518, 518, 518, 518, 518, 518, 518, 518, 
-	518, 518, 518, 518, 518, 518, 518, 0, 
-	519, 522, 522, 522, 523, 526, 526, 526, 
-	529, 529, 529, 530, 531, 532, 533
+	0, 524, 524, 524, 524, 524, 524, 524, 
+	524, 524, 524, 524, 524, 524, 524, 524, 
+	524, 524, 524, 524, 524, 524, 524, 524, 
+	524, 524, 524, 524, 524, 524, 524, 524, 
+	524, 524, 524, 524, 524, 524, 524, 524, 
+	524, 524, 524, 524, 524, 524, 524, 524, 
+	524, 524, 524, 524, 524, 524, 524, 524, 
+	524, 524, 524, 524, 524, 524, 524, 524, 
+	524, 524, 524, 524, 524, 524, 524, 524, 
+	524, 524, 524, 524, 524, 524, 524, 524, 
+	524, 524, 524, 524, 524, 524, 524, 524, 
+	524, 524, 524, 524, 524, 524, 524, 524, 
+	524, 524, 524, 524, 524, 524, 524, 524, 
+	524, 524, 524, 524, 524, 524, 524, 0, 
+	525, 528, 528, 528, 529, 532, 532, 532, 
+	535, 535, 535, 536, 537, 538, 539, 540
 };
 
 static const int bloopnotes_start = 111;
@@ -386,7 +392,8 @@ static const int bloopnotes_error = 0;
 
 static const int bloopnotes_en_main = 111;
 
-#line 154 "c/notation.rl"
+
+#line 157 "c/notation.rl"
 
 
 extern void _bloops_track_add(bloops *B, bloopsatrack *track);
@@ -396,7 +403,7 @@ bloops_track(bloops *B, bloopsaphone *P, char *track, int tracklen)
 {
   int cs, act, oct = 4, len = 4;
   bloopsatrack *S = (bloopsatrack *)malloc(sizeof(bloopsatrack));
-  char tone, mod, fxmod, *p, *pe, *pf, *ts, *te, *eof = 0;
+  char tone, mod, fxmod, dot, *p, *pe, *pf, *ts, *te, *eof = 0;
   bloopsafxcmd fxcmd = (bloopsafxcmd)0;
   float fxval = 0;
 
@@ -409,16 +416,17 @@ bloops_track(bloops *B, bloopsaphone *P, char *track, int tracklen)
   pe = track + tracklen + 1;
 
   
-#line 413 "c/notation.c"
+#line 420 "c/notation.c"
 	{
 	cs = bloopnotes_start;
 	ts = 0;
 	te = 0;
 	act = 0;
 	}
-#line 176 "c/notation.rl"
+
+#line 179 "c/notation.rl"
   
-#line 422 "c/notation.c"
+#line 430 "c/notation.c"
 	{
 	int _klen;
 	unsigned int _trans;
@@ -435,11 +443,11 @@ _resume:
 	_nacts = (unsigned int) *_acts++;
 	while ( _nacts-- > 0 ) {
 		switch ( *_acts++ ) {
-	case 34:
-#line 1 "c/notation.rl"
+	case 35:
+#line 1 "NONE"
 	{ts = p;}
 	break;
-#line 443 "c/notation.c"
+#line 451 "c/notation.c"
 		}
 	}
 
@@ -461,7 +469,7 @@ _resume:
 			else if ( (*p) > *_mid )
 				_lower = _mid + 1;
 			else {
-				_trans += (_mid - _keys);
+				_trans += (unsigned int)(_mid - _keys);
 				goto _match;
 			}
 		}
@@ -484,7 +492,7 @@ _resume:
 			else if ( (*p) > _mid[1] )
 				_lower = _mid + 2;
 			else {
-				_trans += ((_mid - _keys)>>1);
+				_trans += (unsigned int)((_mid - _keys)>>1);
 				goto _match;
 			}
 		}
@@ -505,19 +513,19 @@ _eof_trans:
 		switch ( *_acts++ )
 		{
 	case 0:
-#line 44 "c/notation.rl"
+#line 45 "c/notation.rl"
 	{
     len = ATOI(ts, p - ts);
   }
 	break;
 	case 1:
-#line 48 "c/notation.rl"
+#line 49 "c/notation.rl"
 	{
     oct = ATOI(p - 1, 1);
   }
 	break;
 	case 2:
-#line 52 "c/notation.rl"
+#line 53 "c/notation.rl"
 	{
     switch (tone) {
       case 'a': case 'A':
@@ -556,10 +564,11 @@ _eof_trans:
         else                 NOTE.tone = 'G';
       break;
     }
+    NOTE.dot = dot;
   }
 	break;
 	case 3:
-#line 92 "c/notation.rl"
+#line 94 "c/notation.rl"
 	{
     bloopsafx *fx = (bloopsafx *)malloc(sizeof(bloopsafx));
     fx->next = NOTE.FX;
@@ -571,157 +580,161 @@ _eof_trans:
   }
 	break;
 	case 4:
-#line 102 "c/notation.rl"
+#line 104 "c/notation.rl"
 	{
     fxval = atoi(p-1) * 1.0f;
   }
 	break;
 	case 5:
-#line 106 "c/notation.rl"
+#line 108 "c/notation.rl"
 	{
     fxval += ATOI(pf, p - pf) * pow(0.1f, p - pf);
   }
 	break;
 	case 6:
-#line 110 "c/notation.rl"
+#line 112 "c/notation.rl"
 	{ pf = p; }
 	break;
 	case 7:
-#line 111 "c/notation.rl"
+#line 113 "c/notation.rl"
 	{ fxval *= -1.0f; }
 	break;
 	case 8:
-#line 112 "c/notation.rl"
+#line 114 "c/notation.rl"
 	{ fxcmd = BLOOPS_FX_VOLUME; }
 	break;
 	case 9:
-#line 113 "c/notation.rl"
+#line 115 "c/notation.rl"
 	{ fxcmd = BLOOPS_FX_PUNCH; }
 	break;
 	case 10:
-#line 114 "c/notation.rl"
+#line 116 "c/notation.rl"
 	{ fxcmd = BLOOPS_FX_ATTACK; }
 	break;
 	case 11:
-#line 115 "c/notation.rl"
+#line 117 "c/notation.rl"
 	{ fxcmd = BLOOPS_FX_SUSTAIN; }
 	break;
 	case 12:
-#line 116 "c/notation.rl"
+#line 118 "c/notation.rl"
 	{ fxcmd = BLOOPS_FX_DECAY; }
 	break;
 	case 13:
-#line 117 "c/notation.rl"
+#line 119 "c/notation.rl"
 	{ fxcmd = BLOOPS_FX_SQUARE; }
 	break;
 	case 14:
-#line 118 "c/notation.rl"
+#line 120 "c/notation.rl"
 	{ fxcmd = BLOOPS_FX_SWEEP; }
 	break;
 	case 15:
-#line 119 "c/notation.rl"
+#line 121 "c/notation.rl"
 	{ fxcmd = BLOOPS_FX_VIBE; }
 	break;
 	case 16:
-#line 120 "c/notation.rl"
+#line 122 "c/notation.rl"
 	{ fxcmd = BLOOPS_FX_VSPEED; }
 	break;
 	case 17:
-#line 121 "c/notation.rl"
+#line 123 "c/notation.rl"
 	{ fxcmd = BLOOPS_FX_VDELAY; }
 	break;
 	case 18:
-#line 122 "c/notation.rl"
+#line 124 "c/notation.rl"
 	{ fxcmd = BLOOPS_FX_LPF; }
 	break;
 	case 19:
-#line 123 "c/notation.rl"
+#line 125 "c/notation.rl"
 	{ fxcmd = BLOOPS_FX_LSWEEP; }
 	break;
 	case 20:
-#line 124 "c/notation.rl"
+#line 126 "c/notation.rl"
 	{ fxcmd = BLOOPS_FX_RESONANCE; }
 	break;
 	case 21:
-#line 125 "c/notation.rl"
+#line 127 "c/notation.rl"
 	{ fxcmd = BLOOPS_FX_HPF; }
 	break;
 	case 22:
-#line 126 "c/notation.rl"
+#line 128 "c/notation.rl"
 	{ fxcmd = BLOOPS_FX_HSWEEP; }
 	break;
 	case 23:
-#line 127 "c/notation.rl"
+#line 129 "c/notation.rl"
 	{ fxcmd = BLOOPS_FX_ARP; }
 	break;
 	case 24:
-#line 128 "c/notation.rl"
+#line 130 "c/notation.rl"
 	{ fxcmd = BLOOPS_FX_ASPEED; }
 	break;
 	case 25:
-#line 129 "c/notation.rl"
+#line 131 "c/notation.rl"
 	{ fxcmd = BLOOPS_FX_PHASE; }
 	break;
 	case 26:
-#line 130 "c/notation.rl"
+#line 132 "c/notation.rl"
 	{ fxcmd = BLOOPS_FX_PSWEEP; }
 	break;
 	case 27:
-#line 131 "c/notation.rl"
+#line 133 "c/notation.rl"
 	{ fxcmd = BLOOPS_FX_REPEAT; }
 	break;
 	case 28:
-#line 134 "c/notation.rl"
+#line 136 "c/notation.rl"
 	{ len = 1; }
 	break;
 	case 29:
-#line 135 "c/notation.rl"
+#line 137 "c/notation.rl"
 	{ len = 1; }
 	break;
 	case 30:
-#line 136 "c/notation.rl"
+#line 138 "c/notation.rl"
 	{ mod = p[-1]; }
 	break;
 	case 31:
-#line 138 "c/notation.rl"
+#line 140 "c/notation.rl"
 	{ fxmod = p[-1]; }
 	break;
 	case 32:
-#line 140 "c/notation.rl"
+#line 142 "c/notation.rl"
+	{ dot = 1; }
+	break;
+	case 33:
+#line 143 "c/notation.rl"
 	{ tone = p[-1]; }
 	break;
-	case 35:
-#line 1 "c/notation.rl"
-	{te = p+1;}
-	break;
 	case 36:
-#line 150 "c/notation.rl"
+#line 1 "NONE"
 	{te = p+1;}
 	break;
 	case 37:
-#line 143 "c/notation.rl"
+#line 153 "c/notation.rl"
+	{te = p+1;}
+	break;
+	case 38:
+#line 146 "c/notation.rl"
 	{te = p;p--;{
       NOTE.tone = 0;
       NEXT();
     }}
 	break;
-	case 38:
-#line 147 "c/notation.rl"
+	case 39:
+#line 150 "c/notation.rl"
 	{te = p;p--;{ NEXT(); }}
 	break;
-	case 39:
-#line 148 "c/notation.rl"
+	case 40:
+#line 151 "c/notation.rl"
 	{te = p;p--;{ oct++; len = 4; }}
 	break;
-	case 40:
-#line 149 "c/notation.rl"
+	case 41:
+#line 152 "c/notation.rl"
 	{te = p;p--;{ oct--; len = 4; }}
 	break;
-	case 41:
-#line 147 "c/notation.rl"
+	case 42:
+#line 150 "c/notation.rl"
 	{{p = ((te))-1;}{ NEXT(); }}
 	break;
-#line 725 "c/notation.c"
+#line 738 "c/notation.c"
 		}
 	}
 
@@ -730,11 +743,11 @@ _again:
 	_nacts = (unsigned int) *_acts++;
 	while ( _nacts-- > 0 ) {
 		switch ( *_acts++ ) {
-	case 33:
-#line 1 "c/notation.rl"
+	case 34:
+#line 1 "NONE"
 	{ts = 0;}
 	break;
-#line 738 "c/notation.c"
+#line 751 "c/notation.c"
 		}
 	}
 
@@ -753,7 +766,8 @@ _again:
 
 	_out: {}
 	}
-#line 177 "c/notation.rl"
+
+#line 180 "c/notation.rl"
 
   memcpy(&S->params, &P->params, sizeof(bloopsaparams));
 
@@ -971,7 +985,7 @@ bloops_note_freq(char note, int octave)
 #define KEY(name) key = (void *)&P->params.name
 
 
-#line 975 "c/notation.c"
+#line 989 "c/notation.c"
 static const char _bloopserial_actions[] = {
 	0, 1, 0, 1, 1, 1, 2, 1, 
 	5, 1, 6, 1, 7, 1, 8, 1, 
@@ -1278,7 +1292,8 @@ static const int bloopserial_error = 0;
 
 static const int bloopserial_en_main = 142;
 
-#line 446 "c/notation.rl"
+
+#line 449 "c/notation.rl"
 
 
 bloopsaphone *
@@ -1310,16 +1325,17 @@ bloops_sound_file(bloops *B, char *fname)
 
   P = bloops_square();
   
-#line 1314 "c/notation.c"
+#line 1329 "c/notation.c"
 	{
 	cs = bloopserial_start;
 	ts = 0;
 	te = 0;
 	act = 0;
 	}
-#line 477 "c/notation.rl"
+
+#line 480 "c/notation.rl"
   
-#line 1323 "c/notation.c"
+#line 1339 "c/notation.c"
 	{
 	int _klen;
 	unsigned int _trans;
@@ -1337,10 +1353,10 @@ _resume:
 	while ( _nacts-- > 0 ) {
 		switch ( *_acts++ ) {
 	case 30:
-#line 1 "c/notation.rl"
+#line 1 "NONE"
 	{ts = p;}
 	break;
-#line 1344 "c/notation.c"
+#line 1360 "c/notation.c"
 		}
 	}
 
@@ -1362,7 +1378,7 @@ _resume:
 			else if ( (*p) > *_mid )
 				_lower = _mid + 1;
 			else {
-				_trans += (_mid - _keys);
+				_trans += (unsigned int)(_mid - _keys);
 				goto _match;
 			}
 		}
@@ -1385,7 +1401,7 @@ _resume:
 			else if ( (*p) > _mid[1] )
 				_lower = _mid + 2;
 			else {
-				_trans += ((_mid - _keys)>>1);
+				_trans += (unsigned int)((_mid - _keys)>>1);
 				goto _match;
 			}
 		}
@@ -1406,150 +1422,150 @@ _eof_trans:
 		switch ( *_acts++ )
 		{
 	case 0:
-#line 400 "c/notation.rl"
+#line 403 "c/notation.rl"
 	{
     fval = ATOI(ts, p - ts) * 1.0f;
   }
 	break;
 	case 1:
-#line 404 "c/notation.rl"
+#line 407 "c/notation.rl"
 	{
     fval = ATOI(pf, p - pf) * pow(0.1f, p - pf);
   }
 	break;
 	case 2:
-#line 408 "c/notation.rl"
+#line 411 "c/notation.rl"
 	{ pf = p; }
 	break;
 	case 3:
-#line 409 "c/notation.rl"
+#line 412 "c/notation.rl"
 	{ fval *= -1.0f; }
 	break;
 	case 4:
-#line 410 "c/notation.rl"
+#line 413 "c/notation.rl"
 	{ KEY(volume); }
 	break;
 	case 5:
-#line 411 "c/notation.rl"
+#line 414 "c/notation.rl"
 	{ KEY(arp); }
 	break;
 	case 6:
-#line 412 "c/notation.rl"
+#line 415 "c/notation.rl"
 	{ KEY(aspeed); }
 	break;
 	case 7:
-#line 413 "c/notation.rl"
+#line 416 "c/notation.rl"
 	{ KEY(attack); }
 	break;
 	case 8:
-#line 414 "c/notation.rl"
+#line 417 "c/notation.rl"
 	{ KEY(decay); }
 	break;
 	case 9:
-#line 415 "c/notation.rl"
+#line 418 "c/notation.rl"
 	{ KEY(dslide); }
 	break;
 	case 10:
-#line 416 "c/notation.rl"
+#line 419 "c/notation.rl"
 	{ KEY(freq); }
 	break;
 	case 11:
-#line 417 "c/notation.rl"
+#line 420 "c/notation.rl"
 	{ KEY(hpf); }
 	break;
 	case 12:
-#line 418 "c/notation.rl"
+#line 421 "c/notation.rl"
 	{ KEY(hsweep); }
 	break;
 	case 13:
-#line 419 "c/notation.rl"
+#line 422 "c/notation.rl"
 	{ KEY(limit); }
 	break;
 	case 14:
-#line 420 "c/notation.rl"
+#line 423 "c/notation.rl"
 	{ KEY(lpf); }
 	break;
 	case 15:
-#line 421 "c/notation.rl"
+#line 424 "c/notation.rl"
 	{ KEY(lsweep); }
 	break;
 	case 16:
-#line 422 "c/notation.rl"
+#line 425 "c/notation.rl"
 	{ KEY(phase); }
 	break;
 	case 17:
-#line 423 "c/notation.rl"
+#line 426 "c/notation.rl"
 	{ KEY(psweep); }
 	break;
 	case 18:
-#line 424 "c/notation.rl"
+#line 427 "c/notation.rl"
 	{ KEY(repeat); }
 	break;
 	case 19:
-#line 425 "c/notation.rl"
+#line 428 "c/notation.rl"
 	{ KEY(resonance); }
 	break;
 	case 20:
-#line 426 "c/notation.rl"
+#line 429 "c/notation.rl"
 	{ KEY(slide); }
 	break;
 	case 21:
-#line 427 "c/notation.rl"
+#line 430 "c/notation.rl"
 	{ KEY(square); }
 	break;
 	case 22:
-#line 428 "c/notation.rl"
+#line 431 "c/notation.rl"
 	{ KEY(sustain); }
 	break;
 	case 23:
-#line 429 "c/notation.rl"
+#line 432 "c/notation.rl"
 	{ KEY(sweep); }
 	break;
 	case 24:
-#line 430 "c/notation.rl"
+#line 433 "c/notation.rl"
 	{ KEY(punch); }
 	break;
 	case 25:
-#line 431 "c/notation.rl"
+#line 434 "c/notation.rl"
 	{ KEY(vibe); }
 	break;
 	case 26:
-#line 432 "c/notation.rl"
+#line 435 "c/notation.rl"
 	{ KEY(vspeed); }
 	break;
 	case 27:
-#line 433 "c/notation.rl"
+#line 436 "c/notation.rl"
 	{ KEY(vdelay); }
 	break;
 	case 28:
-#line 434 "c/notation.rl"
+#line 437 "c/notation.rl"
 	{ KEY(volume); }
 	break;
 	case 31:
-#line 438 "c/notation.rl"
+#line 441 "c/notation.rl"
 	{te = p+1;{ P->params.type = BLOOPS_SQUARE; }}
 	break;
 	case 32:
-#line 439 "c/notation.rl"
+#line 442 "c/notation.rl"
 	{te = p+1;{ P->params.type = BLOOPS_SAWTOOTH; }}
 	break;
 	case 33:
-#line 440 "c/notation.rl"
+#line 443 "c/notation.rl"
 	{te = p+1;{ P->params.type = BLOOPS_SINE; }}
 	break;
 	case 34:
-#line 441 "c/notation.rl"
+#line 444 "c/notation.rl"
 	{te = p+1;{ P->params.type = BLOOPS_NOISE; }}
 	break;
 	case 35:
-#line 437 "c/notation.rl"
+#line 440 "c/notation.rl"
 	{te = p;p--;{ *((float *)key) = fval; }}
 	break;
 	case 36:
-#line 442 "c/notation.rl"
+#line 445 "c/notation.rl"
 	{te = p;p--;}
 	break;
-#line 1553 "c/notation.c"
+#line 1569 "c/notation.c"
 		}
 	}
 
@@ -1559,10 +1575,10 @@ _again:
 	while ( _nacts-- > 0 ) {
 		switch ( *_acts++ ) {
 	case 29:
-#line 1 "c/notation.rl"
+#line 1 "NONE"
 	{ts = 0;}
 	break;
-#line 1566 "c/notation.c"
+#line 1582 "c/notation.c"
 		}
 	}
 
@@ -1581,7 +1597,8 @@ _again:
 
 	_out: {}
 	}
-#line 478 "c/notation.rl"
+
+#line 481 "c/notation.rl"
 
 done:
   fclose(fp);

--- a/c/notation.rl
+++ b/c/notation.rl
@@ -36,6 +36,7 @@
   len = 4; \
   fxval = 0; \
   fxmod = 0; \
+  dot = 0; \
   S->nlen++
 
 %%{
@@ -87,6 +88,7 @@
         else                 NOTE.tone = 'G';
       break;
     }
+    NOTE.dot = dot;
   }
 
   action Afx {
@@ -137,7 +139,8 @@
   oct = [1-8] %Aoct;
   fxmod = ( ("+"|"-") %{ fxmod = p[-1]; } (":"|space+) )?;
   fx = ("[" fxcmd (":"|space*) fxmod float "]" %Afx );
-  note = len? [a-gA-G] %{ tone = p[-1]; } mod? oct? fx* %Anote;
+  dot = [.] %{ dot = 1; };
+  note = len? [a-gA-G] %{ tone = p[-1]; } dot? mod? oct? fx* %Anote;
 
   main := |*
     len => {
@@ -160,7 +163,7 @@ bloops_track(bloops *B, bloopsaphone *P, char *track, int tracklen)
 {
   int cs, act, oct = 4, len = 4;
   bloopsatrack *S = (bloopsatrack *)malloc(sizeof(bloopsatrack));
-  char tone, mod, fxmod, *p, *pe, *pf, *ts, *te, *eof = 0;
+  char tone, mod, fxmod, dot, *p, *pe, *pf, *ts, *te, *eof = 0;
   bloopsafxcmd fxcmd = (bloopsafxcmd)0;
   float fxval = 0;
 


### PR DESCRIPTION
Hi! I noticed that [the RTTL spec supported dotted rhythm](https://en.wikipedia.org/wiki/Ring_Tone_Transfer_Language) but bloopsaphone didn't. I took it upon myself to hazard an implementation for it, not knowing much about audio at all. The short and the long of it is that I added a new production to Ragel and a one-line change to `bloopsaphone.c`.

I'm not sure if this is a living project or just an archival of _why's code; I understand if it's just the latter. Thanks!